### PR TITLE
Add topic modeling notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # marketingNotebooks
+
+This repository contains Jupyter notebooks for various marketing analytics tasks.
+
+## Notebooks
+
+- **topic_modeling_wp.ipynb** – Fetches WordPress posts via the REST API and performs topic modeling with scikit-learn's LDA.
+

--- a/topic_modeling_wp.ipynb
+++ b/topic_modeling_wp.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Topic Modeling from WordPress Posts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook fetches post content from a WordPress API and performs topic modeling using Latent Dirichlet Allocation (LDA)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import pandas as pd\n",
+    "from sklearn.feature_extraction.text import TfidfVectorizer\n",
+    "from sklearn.decomposition import LatentDirichletAllocation\n",
+    "\n",
+    "# Replace with your WordPress site API endpoint\n",
+    "WP_API_URL = 'https://example.com/wp-json/wp/v2/posts'\n",
+    "\n",
+    "response = requests.get(WP_API_URL)\n",
+    "response.raise_for_status()\n",
+    "posts = response.json()\n",
+    "texts = [post.get('content', {}).get('rendered', '') for post in posts]\n",
+    "\n",
+    "vectorizer = TfidfVectorizer(stop_words='english')\n",
+    "X = vectorizer.fit_transform(texts)\n",
+    "lda = LatentDirichletAllocation(n_components=5, random_state=0)\n",
+    "lda.fit(X)\n",
+    "\n",
+    "feature_names = vectorizer.get_feature_names_out()\n",
+    "for topic_idx, topic in enumerate(lda.components_):\n",
+    "    print(f'Topic {topic_idx}:')\n",
+    "    print(' '.join(feature_names[i] for i in topic.argsort()[:-11:-1]))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add topic modeling notebook for WordPress posts
- update README with notebook info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b57e60820832fa66540b9c133267b